### PR TITLE
Ein Recht für das AddOn einführen.

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -8,6 +8,7 @@ page:
     pjax: true
     block: poll
     icon: rex-icon fa-hand-spock-o
+    perm: poll[]
     subpages:
 #        main: { title: 'translate:poll_settings' }
         statistic: { title: 'translate:poll_statistic' }


### PR DESCRIPTION
Ein Recht für das AddOn einführen.
Bisher wird das AddOn jedem angezeigt und kann also nicht vor einem User verborgen werden.